### PR TITLE
Fix for charts not showing on turbo navigation

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -119,6 +119,7 @@ module Chartkick
             var createChart = function() { #{createjs} };
             if ("Chartkick" in window) {
               createChart();
+              window.addEventListener("turbo:load", createChart, {once: true});
             } else {
               window.addEventListener("chartkick:load", createChart, true);
             }


### PR DESCRIPTION
This cherry-picks the community fix from https://github.com/ankane/chartkick/issues/608 to re-attach charts after turbo nav.

Fixes https://github.com/OilCan/hotpot/issues/6343.